### PR TITLE
Block designs and latin squares fixed errors

### DIFF
--- a/block_designs.tex
+++ b/block_designs.tex
@@ -114,7 +114,7 @@ Dokážeme postupne jednotlivé body.
 	\item $A A^T = A^T A$. \label{itemF} \\
 	Túto vlastnosť dokážeme priamo pomocou ekvivalentných úprav a vlastností, ktoré sme už dokázali. 
 	\begin{equation*}
-		A A^T = A^{-1} A A^T A \overset{\ref{itemB}}{=} A^{-1} (\lambda J + (k - \lambda) I) A = \lambda A^{-1} J A + (k - \lambda) A^{-1} I A = 
+		A^T A = A^{-1} A A^T A \overset{\ref{itemB}}{=} A^{-1} (\lambda J + (k - \lambda) I) A = \lambda A^{-1} J A + (k - \lambda) A^{-1} I A = 
 	\end{equation*}
 	\begin{equation*}
 		\lambda A^{-1} J A + (k - \lambda) I \overset{\ref{itemE}}{=} \lambda A^{-1} k J + (k - \lambda) I \overset{\ref{itemA}}{=} \lambda A^{-1} A J + (k - \lambda) I = \lambda J + (k - \lambda) I = A A^T

--- a/latin_squares.tex
+++ b/latin_squares.tex
@@ -92,7 +92,7 @@ $$A := \set{x | x \in \set{1, \ldots, n} \wedge \phi(x) \neq \psi(x)}$$
 $$B := \set{y | y \in \set{1, \ldots, n} \wedge \phi(\lambda(y)) \neq \psi(\lambda(y))}$$ 
 (t.j. $\dist(\phi\lambda, \psi\lambda) = |B|$ z definície vzdialenosti \ref{def:permdist}).
 
-Najprv ukážeme, že platí $|A| \geq |B|$, následne $|B| \geq |A|$.
+Najprv ukážeme, že platí $|A| \leq |B|$, následne $|B| \leq |A|$.
 Z toho už platnosť prvého tvrdenia z vety bude očividná.
 
 Nech $x \in A$. 
@@ -194,14 +194,14 @@ a zároveň sú všetky jej prvky rôzne, teda $\forall i, j \in \set{1, \ldots,
 Nech $G = (A \cup B, E)$, kde $E \subseteq A \times B$, je konečný bipartitný graf s partíciami $A$ a $B$.
 Nech $N_G(W)$ je okolie množiny vrcholov $W \subseteq A$.
 Formálne, $N_G(W) := \set{y \in B| \exists x \in W: (x, y) \in E} $
-Potom graf $G$ má úplné párenie práve vtedy keď $$\forall W \subseteq A: |N_G(W)| \geq |W|.$$
+Potom graf $G$ má párenie pokrývajúce množinu $A$ práve vtedy keď $$\forall W \subseteq A: |N_G(W)| \geq |W|.$$
 Neformálne povedané, ak každá podmnožina vrcholov z $A$ má dostatočný počet kandidátov na spárovanie.
 \end{lemma}
 Dôkaz tejto lemy môžete nájsť v knihe \emph{Graph Theory} (Diestel, 2000)\footnote{alebo na Wikipédii: \href{https://en.wikipedia.org/wiki/Hall\%27s_marriage_theorem}{https://en.wikipedia.org/wiki/Hall's\_marriage\_theorem}}.
 
 \begin{theorem}{(Hallova veta pre množiny)}
     Nech $\mathcal{X}$ je systém podmnožín množiny $X$. 
-    Ak $\forall \mathcal{Y} = \set{Y_1, \ldots, Y_m} \subseteq \mathcal{X}: |\bigcup_{Y \in \mathcal{Y}} Y| > m$ tak pre 
+    Ak $\forall \mathcal{Y} = \set{Y_1, \ldots, Y_m} \subseteq \mathcal{X}: |\bigcup_{Y \in \mathcal{Y}} Y| \geq m$ tak pre 
     $\mathcal{X}$ existuje systém rozličných reprezentantov.
 \end{theorem}
 \begin{proof}
@@ -465,7 +465,7 @@ $$
 
 Ak $i \neq k$, tak $a_i - a_k \neq 0$, čiže $a_{k_1} = a_{k_2} \Longrightarrow k_1 = k_2$, čo je spor.
 
-Ak $j \neq l$, tak $a_l - a_j \neq 0$, čiže $(a_i - a_k) a_{k_1} \neq 0 \Longrightarrow a_i \neq a_j \Longrightarrow a_{k_1} = a_{k_2} \Longrightarrow k_1 = k_2$, čo je spor.
+Ak $j \neq l$, tak $a_l - a_j \neq 0$, čiže $(a_i - a_k) a_{k_1} \neq 0 \Longrightarrow a_i \neq a_k \Longrightarrow a_{k_1} = a_{k_2} \Longrightarrow k_1 = k_2$, čo je spor.
 
 Týmto je dôkaz správnosti konštrukcie ukončený.
 


### PR DESCRIPTION
- V blokových plánoch bolo vymenené poradie $AA^T$ a $A^TA$. V starej verzii bolo "dokázané" $AA^T=AA^T$, pričom v prvom kroku bolo $AA^T=A^{-1} A A^T A$, čo nie je pravda.
- V latinských štvorcoch som spravil pár úprav pre lepšiu čitateľnosť, tie veci opisujem v komentároch pre dané zmeny.
- Pri Hallovej vete o párení _úplné párenie_ $\Rightarrow$ _párenie pokrývajúce množinu A_
- Hallova veta pre množiny $\geq$ namiesto >
- Jedna zmena ktorou si nie som úplne istý, dôkaz vety 1.8. v lat. štvorcoch. Tam si nemyslím že vyplýva $a_i \neq a_j$ ale skôr $a_i \neq a_k$, keďže súčin $\neq 0$.